### PR TITLE
chore: bump support for Laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/contracts": "^9.0 || ^10.0 || ^11.0",
+        "illuminate/contracts": "^9.0 || ^10.0 || ^11.0 || ^12.0",
         "aws/aws-sdk-php": "^3"
     },
     "require-dev": {


### PR DESCRIPTION
This bumps the illuminate/contracts version to allow support for Laravel 12.